### PR TITLE
Changed synteny and longest modules to long in label

### DIFF
--- a/modules/local/longest.nf
+++ b/modules/local/longest.nf
@@ -1,6 +1,7 @@
 process LONGEST {
  
     label 'process_single'
+    label 'process_long'
     tag "$sample_id"
     container = 'biocontainers/agat:0.8.0--pl5262hdfd78af_0'
 

--- a/modules/local/synteny.nf
+++ b/modules/local/synteny.nf
@@ -1,6 +1,7 @@
 process SYNTENY {
 
     label 'process_single'
+    label 'process_long'
     tag "${sample_id}_VS_${sample_id2}"
     publishDir "$params.outdir/output_data/anchors" , mode: "copy", pattern: "*.anchors"
     publishDir "$params.outdir/figures/dotplots" , mode: "copy", pattern: "*dotplot.pdf"


### PR DESCRIPTION
This small change should allow jobs to run, if they go over the 1 hour originally allocation.
Tested on myriad, and seems to work now.